### PR TITLE
feat(docs): Create comprehensive project documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@
 
 ## Table of Contents
 
+  - [Documentation](docs/introduction.md)
   - [What is `gitph`?](https://www.google.com/search?q=%23what-is-gitph)
   - [Key Features](https://www.google.com/search?q=%23-key-features)
   - [Architectural Principles](https://www.google.com/search?q=%23-architectural-principles)

--- a/docs/api-reference/core-api.md
+++ b/docs/api-reference/core-api.md
@@ -1,0 +1,97 @@
+# Core API (C-ABI) Reference
+
+This document provides a technical reference for the `gitph` C-ABI, which is the contract between the C core and all dynamically loaded modules. This API is defined in the header file `src/ipc/include/gitph_core_api.h`.
+
+## Required Module Functions
+
+Every `gitph` module **must** export the following four functions with C linkage (`extern "C"`).
+
+---
+
+### `const GitphModuleInfo* module_get_info(void)`
+
+This function is called by the core immediately after the module is loaded. It should return a pointer to a static, read-only `GitphModuleInfo` struct containing metadata about the module.
+
+- **Returns:** A pointer to a `GitphModuleInfo` struct. The pointer and its contents must remain valid for the lifetime of the application.
+
+---
+
+### `GitphStatus module_init(const GitphCoreContext* context)`
+
+This function is called once at startup. It is where the module should perform any necessary initialization, such as allocating memory or setting up internal state. It receives a pointer to the `GitphCoreContext` which provides access to core services.
+
+- **Parameters:**
+  - `context` (const GitphCoreContext*): A pointer to the core context object. The module should store this context if it needs to call back into the core later.
+- **Returns:** `GITPH_SUCCESS` on success, or an error code from the `GitphStatus` enum on failure.
+
+---
+
+### `GitphStatus module_exec(int argc, const char** argv)`
+
+This function is called whenever a user runs a command that this module has registered (via `module_get_info`).
+
+- **Parameters:**
+  - `argc` (int): The number of arguments. `argv[0]` is the command name itself.
+  - `argv` (const char**): An array of null-terminated strings representing the arguments.
+- **Returns:** `GITPH_SUCCESS` on success, or an error code on failure.
+
+---
+
+### `void module_cleanup(void)`
+
+This function is called once at shutdown. The module must free any resources it allocated during its lifetime to prevent memory leaks.
+
+## Core Data Structures
+
+These are the primary data structures used for communication between the core and the modules.
+
+---
+
+### `struct GitphModuleInfo`
+
+A struct used to pass module metadata to the core.
+
+- **Fields:**
+  - `const char* name`: The unique name of the module (e.g., `"git_ops"`).
+  - `const char* version`: The module's version string (e.g., `"1.0.0"`).
+  - `const char* description`: A brief description of the module.
+  - `const char** commands`: A `NULL`-terminated array of command strings that the module handles.
+
+---
+
+### `struct GitphCoreContext`
+
+A struct passed from the core to the module during `module_init`. It contains function pointers that allow the module to safely access core services.
+
+- **Fields (Function Pointers):**
+  - `void (*log)(GitphLogLevel level, const char* module_name, const char* message)`: A pointer to the core's simple logging function.
+  - `void (*log_fmt)(GitphLogLevel level, const char* module_name, const char* format, ...)`: A pointer to the core's safe, printf-style logging function. This is recommended over the simple `log` function for variable-length messages.
+  - `const char* (*get_config_value)(const char* key)`: Retrieves a value from the core's configuration manager.
+  - `void (*print_ui)(const char* text)`: Prints text to the user's console, managed by the core's UI system.
+
+---
+
+### `enum GitphStatus`
+
+A standard set of status codes for return values.
+
+- **Values:**
+  - `GITPH_SUCCESS` (0)
+  - `GITPH_ERROR_GENERAL` (-1)
+  - `GITPH_ERROR_INVALID_ARGS` (-2)
+  - `GITPH_ERROR_NOT_FOUND` (-3)
+  - `GITPH_ERROR_INIT_FAILED` (-4)
+  - `GITPH_ERROR_EXEC_FAILED` (-5)
+
+---
+
+### `enum GitphLogLevel`
+
+Defines the severity levels for the logging system.
+
+- **Values:**
+  - `LOG_LEVEL_DEBUG`
+  - `LOG_LEVEL_INFO`
+  - `LOG_LEVEL_WARN`
+  - `LOG_LEVEL_ERROR`
+  - `LOG_LEVEL_FATAL`

--- a/docs/api-reference/lua-api.md
+++ b/docs/api-reference/lua-api.md
@@ -1,0 +1,74 @@
+# Lua API Reference
+
+This document provides a technical reference for the API exposed to Lua scripts by the `gitph` core.
+
+## The `gitph` Table
+
+All core functions are exposed through a single global table named `gitph`.
+
+---
+
+### `gitph.log(level, message)`
+
+Writes a message to the main `gitph` log file.
+
+- **Parameters:**
+  - `level` (string): The log level. Must be one of `"DEBUG"`, `"INFO"`, `"WARN"`, `"ERROR"`, or `"FATAL"`.
+  - `message` (string): The log message to write.
+
+- **Returns:** `nil`
+
+- **Example:**
+  ```lua
+  gitph.log("INFO", "My plugin has started.")
+  ```
+
+---
+
+### `gitph.register_alias(alias, original_command)`
+
+Creates a new command that serves as an alias for an existing command. This must be called during the initial script load.
+
+- **Parameters:**
+  - `alias` (string): The new, shorter command name you want to create.
+  - `original_command` (string): The name of the existing `gitph` command that the alias should execute.
+
+- **Returns:** `nil`
+
+- **Example:**
+  ```lua
+  -- Allows 'gitph st' to run the 'status' command.
+  gitph.register_alias("st", "status")
+  ```
+
+---
+
+## Global Hook Functions
+
+`gitph` can be configured to call specific, globally-defined functions in your Lua scripts at certain points in its lifecycle. You implement a hook by simply defining a global function with the correct name and parameters.
+
+---
+
+### `on_pre_push(remote, branch)`
+
+This function, if defined, is called just before a `git push` operation is executed by a `gitph` command (e.g., `SND`). It allows you to cancel the push.
+
+- **Parameters:**
+  - `remote` (string): The name of the remote target (e.g., `"origin"`).
+  - `branch` (string): The name of the branch being pushed (e.g., `"feature/my-work"`).
+
+- **Return Value:**
+  - `boolean`:
+    - `true`: The push is allowed to continue.
+    - `false` or `nil`: The push is aborted.
+
+- **Example:**
+  ```lua
+  function on_pre_push(remote, branch)
+    if branch == "main" then
+      print("Error: Direct pushes to main are not allowed.")
+      return false
+    end
+    return true
+  end
+  ```

--- a/docs/developer-guide/architecture.md
+++ b/docs/developer-guide/architecture.md
@@ -1,0 +1,78 @@
+# gitph Architecture
+
+`gitph` is built on a modular, polyglot, message-passing architecture. This design is a deliberate choice to use the best language for each task, promoting safety, performance, and extensibility. At its heart is a lightweight C core that acts as an orchestrator for a suite of external modules.
+
+```mermaid
+graph TD
+    subgraph User Interaction
+        A[CLI / TUI]
+    end
+
+    subgraph "gitph Core (C Language)"
+        B[Orchestrator & Entry Point]
+        B -- "Loads modules via FFI" --> C{Dynamic Module Loader}
+        C -- "Loads" --> D[Rust Modules (.so, .dll, .dylib)]
+        C -- "Loads" --> E[C++ Modules (.so, .dll, .dylib)]
+        C -- "Initializes" --> F[Lua Scripting Engine]
+        F -- "Executes" --> G[User Plugins (.lua)]
+    end
+
+    subgraph "Module & Plugin Ecosystem"
+        D -- "Memory Safety, Concurrency" --> D1[git_ops]
+        D -- "Stateful Logic, Performance" --> D2[sync_engine]
+        D -- "Asynchronous I/O (Tokio)" --> D3[issue_tracker]
+        E -- "RAII, OOP Design" --> E1[liblogger]
+        G -- "User-Defined Aliases" --> G1[custom_aliases.lua]
+        G -- "User-Defined Hooks" --> G2[pre_push_hook.lua]
+    end
+
+    A --> B
+```
+
+## Core Components
+
+### The C Core (The Orchestrator)
+
+The core of `gitph` is written in C for several key reasons:
+- **Portability:** C has a minimal runtime and is the most portable language for system-level programming.
+- **Stable ABI:** The C Application Binary Interface (ABI) is stable and well-understood, making it the perfect foundation for a Foreign Function Interface (FFI). This allows modules written in other languages (like Rust, C++, Go, etc.) to communicate with the core.
+- **Control:** It provides low-level control over memory and process management, which is essential for an orchestrator that loads and manages other components.
+
+The core is responsible for:
+1.  **Parsing command-line arguments.**
+2.  **Initializing subsystems** like logging and configuration.
+3.  **Discovering and dynamically loading** all modules (shared libraries) from the `modules` directory.
+4.  **Initializing the Lua scripting engine** and loading all user plugins.
+5.  **Dispatching commands** to the appropriate module or Lua script.
+6.  **Providing core services** (like logging) to modules via a well-defined API.
+
+### The C++ Libraries (High-Performance Components)
+
+C++ is used for specific, self-contained libraries where its features provide a clear advantage over C.
+- **Object-Oriented Programming (OOP):** C++ allows for better encapsulation and design for complex components.
+- **RAII (Resource Acquisition Is Initialization):** This C++ pattern simplifies resource management (memory, file handles, mutexes), leading to more robust and leak-free code. A prime example is the `liblogger` component, which uses RAII to manage log files and threading primitives safely.
+
+### The Rust Modules (Safe and Concurrent Logic)
+
+Rust is the language of choice for the majority of `gitph`'s business logic. All modules that handle complex operations, interact with the network, or perform critical tasks are written in Rust.
+- **Memory Safety:** Rust's ownership and borrow checker guarantees memory safety at compile time, eliminating entire classes of bugs like null pointer dereferences, buffer overflows, and data races. This is critical for a tool that operates on user data and repositories.
+- **Fearless Concurrency:** Rust makes it easier to write correct concurrent and asynchronous code, which is essential for modules like the `issue_tracker` that perform network requests without blocking the main application.
+- **Performance:** Rust provides performance on par with C and C++, making it ideal for performance-sensitive tasks like the `sync_engine`.
+
+### The Lua Scripts (User-Facing Extensibility)
+
+Lua is embedded into the C core as a small, fast, and safe scripting language. It is not used for core logic but is provided as a way for **end-users** to customize and extend `gitph`'s behavior without needing to compile code.
+- **Sandboxed:** The Lua environment is controlled by the C core, limiting what scripts can do and preventing them from crashing the main application.
+- **Easy to Learn:** Lua has a simple syntax, making it accessible to users who are not professional programmers.
+- **Dynamic:** Users can add or modify Lua scripts and have the changes reflected on the next run of `gitph`, without any need for recompilation.
+
+## Communication: The FFI Contract
+
+The magic that holds this polyglot system together is the **Foreign Function Interface (FFI)**. The core defines a strict, C-compatible API in the `gitph_core_api.h` header file. This file acts as a contract that all modules must adhere to.
+
+- Any module, whether written in Rust, C++, or another language, must export a specific set of C-compatible functions.
+- The C core uses `dlopen()` (or `LoadLibrary` on Windows) to load these modules as shared libraries at runtime.
+- It then uses `dlsym()` (or `GetProcAddress`) to find the addresses of the required functions.
+- When a module is initialized, the core passes it a `GitphCoreContext` struct. This struct contains function pointers back to core services, allowing the module to log messages or access configuration in a controlled way (a form of dependency injection).
+
+This architecture makes `gitph` a true platform. New functionality can be added by simply dropping a new shared library into the `modules` directory, and the core will automatically discover and integrate it.

--- a/docs/developer-guide/core-development.md
+++ b/docs/developer-guide/core-development.md
@@ -1,0 +1,62 @@
+# Core Development Guide
+
+This guide is for advanced developers who intend to modify or contribute to the `gitph` C core. The core is the central orchestrator of the application, responsible for loading modules, managing subsystems, and dispatching commands.
+
+## 1. Code Structure
+
+The C core source code is located in `src/core/`. It is organized into several subdirectories, each with a specific responsibility:
+
+- `main/`: Contains the main entry point of the application (`main.c`).
+- `cli/`: Handles parsing of command-line arguments and dispatching them to the correct module.
+- `config/`: Manages loading and accessing configuration files.
+- `module_loader/`: Responsible for discovering and dynamically loading shared library modules.
+- `scripting/`: Contains the bridge to the embedded Lua engine.
+- `ui/`: Implements the interactive Text-based User Interface (TUI).
+- `platform/`: Contains platform-specific code (e.g., for Windows vs. POSIX systems) to ensure portability.
+
+## 2. The Application Lifecycle (`main.c`)
+
+The application's entry point, `main()`, provides a clear overview of the startup and shutdown sequence. Understanding this sequence is critical for core development.
+
+### Startup Sequence
+
+The core initializes subsystems in a specific, non-negotiable order to ensure dependencies are met.
+
+1.  `platform_global_init()`: Performs any required platform-specific setup first.
+2.  `logger_init()`: The logging system is initialized early so that all subsequent subsystems can log their status.
+3.  `config_load()`: The configuration is loaded. This is not fatal if it fails; the application can proceed with default values.
+4.  `lua_bridge_init()`: The Lua scripting engine is initialized. This must happen before modules are loaded, as modules might depend on Lua being available.
+5.  `modules_load()`: The module loader searches the `./modules` directory for shared libraries, loads them, and registers their commands. This is a critical step; if it fails, the application will exit.
+
+After initialization, the core inspects the command-line arguments (`argc`):
+- If `argc < 2`, no command was provided, so `tui_show_main_menu()` is called to enter interactive mode.
+- Otherwise, the arguments are passed to `cli_dispatch_command()` to be executed.
+
+### Shutdown Sequence
+
+A `goto cleanup` pattern is used to ensure a graceful shutdown. The cleanup functions are called in the reverse order of initialization to safely deallocate all resources.
+
+1.  `modules_cleanup()`: Calls the `module_cleanup` function in every loaded module.
+2.  `lua_bridge_cleanup()`: Releases all resources used by the Lua engine.
+3.  `config_cleanup()`: Frees memory used by the configuration manager.
+4.  `logger_cleanup()`: Flushes and closes the log file.
+5.  `platform_global_cleanup()`: Performs any platform-specific cleanup.
+
+## 3. The Build System (`CMake` and `Makefile`)
+
+`gitph` uses `CMake` as its primary build system, with a `Makefile` wrapper for convenience.
+
+- **`CMakeLists.txt` (Root):** This is the main build script. It finds the necessary compilers and libraries, and it includes the `src` and `tests` directories.
+- **`src/CMakeLists.txt`:** This script defines the `gitph` executable. It links the core C source files together and ensures that the C++ `liblogger` is also compiled and linked. It also specifies the directories where headers can be found.
+- **`Makefile`:** This provides simple, user-friendly commands like `make`, `make clean`, and `make install`. It is a wrapper around the more complex `cmake` commands, making the build process easier for developers. For example, `make` will automatically create a `build` directory, run `cmake`, and then run the actual build command (`make` or `ninja`).
+
+When you run `make`, the build system compiles the C core into an executable (`build/bin/gitph`) and also places the compiled Rust/C++ modules (which are built separately via Cargo or other means) into the `build/modules/` directory, from where the executable can load them at runtime.
+
+## 4. Coding Conventions
+
+The C code in the core follows a few consistent conventions:
+
+- **Comments:** The code is extensively commented using C-style `/* ... */` blocks. Header comments explain the purpose of the file, and function headers use a Doxygen-like format to explain parameters and return values.
+- **Naming:** Functions and variables use `snake_case`. Header guards use the pattern `GITPH_DIR_FILE_H`.
+- **Error Handling:** Functions that can fail typically return a `GitphStatus` enum. This provides a consistent way to handle errors across the application.
+- **Headers:** Each `.c` file has a corresponding `.h` file that declares its public interface. Internal or static functions are not exposed in the header.

--- a/docs/developer-guide/module-development.md
+++ b/docs/developer-guide/module-development.md
@@ -1,0 +1,196 @@
+# Module Development Guide
+
+This guide provides a comprehensive walkthrough for creating your own modules to extend `gitph`'s functionality. Modules are the primary way to add new, complex features to `gitph`. They are dynamically loaded shared libraries that can be written in any language that can export C symbols, though Rust is the recommended and most supported choice.
+
+This guide will use the existing `git_ops` module as a real-world example.
+
+## 1. The Module's Role
+
+A `gitph` module is a self-contained unit of functionality. It is responsible for:
+- Registering one or more commands with the `gitph` core.
+- Executing the logic for those commands.
+- Interacting with the core application (for logging, configuration, etc.) in a safe, controlled manner.
+
+## 2. The FFI Contract: `gitph_core_api.h`
+
+The foundation of module development is the C-ABI contract defined in `src/ipc/include/gitph_core_api.h`. This header file defines four functions that **every module must export** and the data structures used to communicate with the core.
+
+### Required Exported Functions
+
+- `PFN_module_get_info`: Returns metadata about the module (name, version, commands).
+- `PFN_module_init`: Called once at startup to initialize the module. It receives the `GitphCoreContext`.
+- `PFN_module_exec`: Called whenever a user runs one of the module's registered commands.
+- `PFN_module_cleanup`: Called once at shutdown for the module to clean up its resources.
+
+### Key Data Structures
+
+- `GitphModuleInfo`: A struct containing your module's metadata.
+- `GitphCoreContext`: A struct containing function pointers that your module can use to call back into the `gitph` core (e.g., for logging).
+- `GitphStatus`: An enum for returning success or error codes back to the core.
+
+## 3. Creating a Rust Module: A Step-by-Step Guide
+
+Let's walk through how the `git_ops` module is implemented in Rust.
+
+### Step 3.1: `Cargo.toml` Configuration
+
+To compile a Rust project into a C-compatible shared library, you need to configure the crate type in your `Cargo.toml`.
+
+```toml
+[lib]
+name = "git_ops"
+crate-type = ["cdylib"] # Compile to a C-Dynamic Library
+```
+
+### Step 3.2: Replicating the C-ABI in Rust
+
+Your `lib.rs` file must replicate the C data structures from `gitph_core_api.h`. You use the `#[repr(C)]` attribute to ensure the memory layout is compatible with C.
+
+```rust
+// src/modules/git_ops/src/lib.rs
+
+// These must match the C definitions exactly.
+#[repr(C)]
+pub enum GitphStatus {
+    Success = 0,
+    ErrorGeneral = -1,
+    // ... and so on
+}
+
+#[repr(C)]
+pub struct GitphCoreContext {
+    log: Option<extern "C" fn(...)>,
+    // ... other function pointers
+}
+
+#[repr(C)]
+pub struct GitphModuleInfo {
+    name: *const libc::c_char,
+    version: *const libc::c_char,
+    description: *const libc::c_char,
+    commands: *const *const libc::c_char,
+}
+```
+
+### Step 3.3: Implementing `module_get_info`
+
+This function returns a pointer to a static struct containing your module's information.
+
+```rust
+// src/modules/git_ops/src/lib.rs
+
+// Define the static data for the module info.
+// Note the null terminators (\0) for C compatibility.
+static MODULE_NAME: &[u8] = b"git_ops\0";
+static MODULE_VERSION: &[u8] = b"0.2.0\0";
+static MODULE_DESC: &[u8] = b"Provides intelligent Git commands.\0";
+
+// Define the commands this module handles.
+// The list must be null-terminated.
+const SUPPORTED_COMMANDS_PTRS: &[*const libc::c_char] = &[
+    b"SND\0".as_ptr() as *const libc::c_char,
+    b"status\0".as_ptr() as *const libc::c_char,
+    std::ptr::null(), // Null terminator
+];
+
+// Create the static info struct.
+static MODULE_INFO: GitphModuleInfo = GitphModuleInfo {
+    name: MODULE_NAME.as_ptr() as *const libc::c_char,
+    version: MODULE_VERSION.as_ptr() as *const libc::c_char,
+    description: MODULE_DESC.as_ptr() as *const libc::c_char,
+    commands: SUPPORTED_COMMANDS_PTRS.as_ptr(),
+};
+
+// Export the function with a C-compatible name.
+#[no_mangle]
+pub extern "C" fn module_get_info() -> *const GitphModuleInfo {
+    &MODULE_INFO
+}
+```
+
+### Step 3.4: Implementing `module_init`
+
+This function receives the core context and should store it for later use. A `lazy_static` mutex is a good way to store this context safely in a global variable.
+
+```rust
+// src/modules/git_ops/src/lib.rs
+
+lazy_static::lazy_static! {
+    static ref CORE_CONTEXT: Mutex<Option<GitphCoreContext>> = Mutex::new(None);
+}
+
+#[no_mangle]
+pub extern "C" fn module_init(context: *const GitphCoreContext) -> GitphStatus {
+    if context.is_null() {
+        return GitphStatus::ErrorInitFailed;
+    }
+    // Store the context for later use by the log_to_core helper function.
+    if let Ok(mut guard) = CORE_CONTEXT.lock() {
+        *guard = Some(unsafe { std::ptr::read(context) });
+    } else {
+        return GitphStatus::ErrorInitFailed;
+    }
+    // ...
+    GitphStatus::Success
+}
+```
+
+### Step 3.5: Implementing `module_exec`
+
+This is the workhorse function. It receives the command-line arguments from the core, dispatches them to the correct internal Rust function, and translates the result back into a `GitphStatus`.
+
+```rust
+#[no_mangle]
+pub extern "C" fn module_exec(argc: c_int, argv: *const *const c_char) -> GitphStatus {
+    // 1. Safely convert C arguments to a Rust Vec<String>.
+    let args: Vec<String> = (0..argc as isize)
+        .map(|i| unsafe {
+            let c_str_ptr = *argv.offset(i);
+            CStr::from_ptr(c_str_ptr).to_string_lossy().into_owned()
+        })
+        .collect();
+
+    // 2. Get the command (the first argument).
+    let command = args[0].as_str();
+
+    // 3. Dispatch to your internal Rust logic.
+    let result = match command {
+        "SND" => commands::handle_send(/* ... */),
+        "status" => commands::handle_status(/* ... */),
+        _ => Err(/* ... */),
+    };
+
+    // 4. Translate your internal Rust error type to a GitphStatus.
+    match result {
+        Ok(success_message) => {
+            println!("{}", success_message); // Print to user
+            GitphStatus::Success
+        }
+        Err(e) => {
+            eprintln!("Error: {}", e); // Print error to user
+            GitphStatus::ErrorExecFailed
+        }
+    }
+}
+```
+
+### Step 3.6: Implementing `module_cleanup`
+
+This function is for freeing any resources your module allocated during its lifetime.
+
+```rust
+#[no_mangle]
+pub extern "C" fn module_cleanup() {
+    // This is a good place to log a shutdown message.
+    log_to_core(GitphLogLevel::Info, "git_ops module cleaned up.");
+}
+```
+
+## 4. Building and Deploying the Module
+
+To build your module, simply run `cargo build --release` in your module's directory. This will produce a shared library file:
+- `target/release/libgit_ops.so` on Linux
+- `target/release/libgit_ops.dylib` on macOS
+- `target/release/git_ops.dll` on Windows
+
+Finally, copy this shared library file into the `build/modules/` directory of your main `gitph` project. The next time you run `gitph`, the core will automatically discover, load, and register the commands from your new module.

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -1,0 +1,3 @@
+# Introduction to gitph
+
+Welcome to the official documentation for `gitph`, the polyglot assistant for Git & DevOps Workflows. This documentation is designed to help you understand, use, and extend the `gitph` tool.

--- a/docs/user-guide/getting-started.md
+++ b/docs/user-guide/getting-started.md
@@ -1,0 +1,83 @@
+# Getting Started with gitph
+
+This guide will walk you through the basic usage of `gitph`, from running your first command to using its powerful interactive mode.
+
+## Command Structure
+
+`gitph` follows a standard command-line structure:
+
+```
+gitph [COMMAND] [ARGUMENTS...]
+```
+
+- `COMMAND`: The name of the action you want to perform (e.g., `SND`, `status`, `vault-read`).
+- `ARGUMENTS`: Additional information required by the command (e.g., a commit message, a file path).
+
+You can see a list of all available commands by running `gitph --help` or by launching the interactive TUI.
+
+## Interactive TUI Mode
+
+If you run `gitph` without any arguments, you will enter a Text-based User Interface (TUI).
+
+```bash
+gitph
+```
+
+This mode is a great way to explore `gitph`'s capabilities. It provides a menu of all loaded commands from every module, with descriptions of what they do. You can navigate the menu with your arrow keys and press `Enter` to execute a command. The TUI will then prompt you for any required arguments.
+
+## Core Commands Showcase
+
+Here are a few examples of `gitph`'s key features in action.
+
+### The "One-Shot" Send (`SND`)
+
+The `SND` command is a powerful workflow enhancement that automates the standard `git add .`, `git commit -m "..."`, and `git push` cycle. It's intelligent enough to know when there are no changes to commit, preventing empty commits.
+
+**Usage:**
+
+```bash
+gitph SND "Your commit message here"
+```
+
+**How it works:**
+
+1.  `gitph` stages all unstaged changes in your current directory (`git add .`).
+2.  It commits the staged changes with the message you provided.
+3.  It pushes the commit to the configured upstream branch.
+4.  If there are no changes to commit, it will inform you and exit gracefully.
+
+This single command saves you time and streamlines the process of getting your local work pushed to your remote repository.
+
+### Securely Read Secrets (`vault-read`)
+
+The `devops_automation` module allows `gitph` to interact with other command-line tools and parse their output. A great example is the `vault-read` command, which securely reads a secret from HashiCorp Vault and displays it in a clean, human-readable format.
+
+**Usage:**
+
+```bash
+gitph vault-read secret/data/prod/api-keys
+```
+
+**How it works:**
+
+- Instead of just running `vault kv get -format=json ...` and giving you raw JSON, `gitph` captures the output.
+- It parses the JSON data internally and displays the secret's key-value pairs, making it easy to find the information you need without piping the output to tools like `jq`.
+
+### Safe Repository Synchronization (`sync-run`)
+
+The `sync-engine` provides a stateful, bi-directional synchronization mechanism that is safer than simple `git mirror` or `rsync` operations. It's designed to prevent accidental data loss when syncing repositories that may have diverged.
+
+**Usage:**
+
+```bash
+gitph sync-run /path/to/source-repo /path/to/target-repo
+```
+
+**How it works:**
+
+1.  The `sync-engine` analyzes the commit history of both the source and target repositories.
+2.  It creates a state file inside the source repository's `.git` directory to track sync operations.
+3.  It detects if the branches have diverged (i.e., if both have unique commits).
+4.  If divergence is detected, it will warn you and prevent a sync that could overwrite history, prompting you to manually resolve the divergence first.
+
+This makes `sync-run` a powerful tool for maintaining forks or backups of a repository.

--- a/docs/user-guide/installation.md
+++ b/docs/user-guide/installation.md
@@ -1,0 +1,93 @@
+# Installation
+
+`gitph` is designed to be built from source on a variety of platforms. We also offer pre-built packages for several popular package managers to simplify the installation process.
+
+## Option 1: Installing from a Package Manager (Recommended)
+
+Using a package manager is the easiest way to get `gitph` up and running.
+
+### Homebrew (macOS)
+
+If you are on macOS and use Homebrew, you can install `gitph` from our official tap:
+
+```bash
+brew install phkaiser13/peitchgit/gitph
+```
+
+### Chocolatey (Windows)
+
+If you are on Windows and use Chocolatey, you can install `gitph` with the following command:
+
+```bash
+choco install gitph
+```
+
+### Arch User Repository (Arch Linux)
+
+For Arch Linux users, `gitph` is available on the AUR. You can use an AUR helper like `yay` to install it:
+
+```bash
+yay -S gitph
+```
+
+## Option 2: Building from Source
+
+If a package is not available for your system, or if you want to build the latest development version, you can build `gitph` from source.
+
+### Prerequisites
+
+Before you begin, you need to install the necessary development toolchain for your platform. `gitph` is a polyglot project and requires:
+
+- A modern C/C++ compiler (e.g., GCC, Clang, MSVC)
+- `cmake` (version 3.15 or newer)
+- `git`
+- The Rust toolchain (`rustc` and `cargo`)
+- Development headers for `libcurl` and `lua`
+
+We provide a convenience script to help set up this environment on some systems.
+
+```bash
+# On Debian/Ubuntu-based systems
+sudo apt-get update
+sudo apt-get install build-essential cmake git curl libcurl4-openssl-dev liblua5.4-dev
+
+# On Fedora/RHEL-based systems
+sudo dnf groupinstall "Development Tools"
+sudo dnf install cmake git curl libcurl-devel lua-devel
+
+# On macOS (using Homebrew)
+brew install cmake git rust lua
+
+# For Rust, we recommend installing via rustup
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+```
+
+### Build Steps
+
+Once the prerequisites are installed, you can clone the repository and build the project using our `Makefile` wrapper, which simplifies the `cmake` process.
+
+1.  **Clone the repository:**
+    ```bash
+    git clone https://github.com/phkaiser13/peitchgit.git
+    cd peitchgit
+    ```
+
+2.  **Build the project:**
+    The `make` command will configure the project with `cmake` and then compile the entire application.
+    ```bash
+    make
+    ```
+    This will create a `build` directory containing the compiled binaries.
+
+3.  **Run `gitph`:**
+    The main executable will be located at `build/bin/gitph`.
+    ```bash
+    ./build/bin/gitph --version
+    ```
+
+4.  **(Optional) Install the binary:**
+    To make `gitph` available system-wide, you can install it to a location in your `PATH`.
+    ```bash
+    sudo make install
+    ```
+    This will typically install the binary to `/usr/local/bin`.

--- a/docs/user-guide/lua-scripting.md
+++ b/docs/user-guide/lua-scripting.md
@@ -1,0 +1,97 @@
+# Extending gitph with Lua
+
+One of `gitph`'s most powerful features is its extensibility through a built-in Lua scripting engine. This allows you to tailor `gitph` to your specific workflow without modifying the core application. You can create custom command aliases, hook into Git events to enforce policies, and much more.
+
+## The Plugin System
+
+`gitph` automatically loads any Lua script (`.lua` file) it finds in the `src/plugins/` directory at startup. To create a new plugin, simply add a new `.lua` file to this directory.
+
+## The `gitph` Global Table
+
+When your script is executed, `gitph` exposes a global Lua table named `gitph`. This table contains all the API functions you can use to interact with the core application.
+
+### Logging from Lua
+
+You can write to the main `gitph` log file from your script using the `gitph.log()` function. This is useful for debugging your plugins.
+
+**Syntax:**
+`gitph.log(log_level, message)`
+
+- `log_level`: A string representing the level ("INFO", "WARN", "ERROR", "DEBUG").
+- `message`: The string message to log.
+
+**Example:**
+```lua
+gitph.log("INFO", "My custom plugin has loaded successfully!")
+```
+
+## Creating Command Aliases
+
+Do you have a long `gitph` command you type frequently? You can create a shorter alias for it with the `gitph.register_alias()` function.
+
+**Syntax:**
+`gitph.register_alias(alias, original_command)`
+
+- `alias`: The new, shorter command name.
+- `original_command`: The existing `gitph` command you want to alias.
+
+**Example: `my_aliases.lua`**
+Let's create a plugin to add some convenient shortcuts. Create a file named `src/plugins/my_aliases.lua`:
+
+```lua
+-- File: src/plugins/my_aliases.lua
+
+-- Log to confirm the plugin is loading
+gitph.log("INFO", "Loading custom aliases.")
+
+-- Create a short alias 'st' for the 'status' command
+gitph.register_alias("st", "status")
+
+-- Create a 'commit-push' alias for the 'SND' command
+gitph.register_alias("cp", "SND")
+
+gitph.log("INFO", "Custom aliases 'st' and 'cp' registered.")
+```
+
+After restarting `gitph` (or running it for the first time after adding the file), you can now run `gitph st` instead of `gitph status`, and `gitph cp` instead of `gitph SND`.
+
+## Hooking into the Git Lifecycle
+
+`gitph` allows you to define special global functions in your Lua scripts that act as "hooks." These hooks are automatically called by the `gitph` core at specific points in the Git lifecycle, allowing you to run custom logic.
+
+### The `on_pre_push` Hook
+
+The `on_pre_push` hook is called just before a `git push` operation is executed (for example, via the `SND` command). It allows you to inspect the push and even cancel it if certain conditions aren't met.
+
+**Syntax:**
+`function on_pre_push(remote, branch)`
+
+- `remote`: The name of the remote the push is targeting (e.g., "origin").
+- `branch`: The name of the branch being pushed.
+- **Return Value**:
+  - `true`: The push is allowed to proceed.
+  - `false`: The push is cancelled.
+
+**Example: Enforcing Branch Policy**
+Let's create a plugin to prevent direct pushes to the `main` or `master` branches. Create a file named `src/plugins/policy.lua`:
+
+```lua
+-- File: src/plugins/policy.lua
+
+-- This global function is automatically called by the gitph core before a push.
+function on_pre_push(remote, branch)
+    if branch == "main" or branch == "master" then
+        -- Print a message to the user
+        print("[POLICY] Direct pushes to the '" .. branch .. "' branch are forbidden.")
+        print("Please use a pull request workflow.")
+
+        -- Cancel the push
+        return false
+    end
+
+    -- Allow pushes to any other branch
+    return true
+end
+```
+
+With this plugin active, any attempt to push to `main` or `master` using a `gitph` command will be blocked, helping you enforce team development policies.


### PR DESCRIPTION
This commit adds a complete documentation suite for the `gitph` project, housed in the `/docs` directory. The goal is to provide clear, extensive, and professional documentation for all types of users.

The documentation is structured into three main sections:

1.  **User Guide:**
    - `installation.md`: Detailed instructions for package managers and building from source.
    - `getting-started.md`: A tutorial on basic commands and the TUI.
    - `lua-scripting.md`: A guide to extending `gitph` with Lua for aliases and hooks.

2.  **Developer Guide:**
    - `architecture.md`: An in-depth explanation of the polyglot architecture.
    - `module-development.md`: A tutorial on creating new modules in Rust.
    - `core-development.md`: A guide for developers working on the C core.

3.  **API Reference:**
    - `lua-api.md`: Reference for the Lua scripting API.
    - `core-api.md`: Reference for the C-ABI used by modules.

Additionally, the main `README.md` has been updated to include a link to this new documentation, making it easily accessible.